### PR TITLE
feat: implement day/night timer cycle and customer state entity

### DIFF
--- a/src/Dependencies.lua
+++ b/src/Dependencies.lua
@@ -9,6 +9,7 @@ _G.suit = require('src.libs.SUIT')
 require('src.constants')
 
 require('src.states.BaseState')
+require('src.states.entity.CustomerState')
 require('src.states.game.PlayState')
 require('src.states.game.StartMenu')
 require('src.states.game.DayEndState')

--- a/src/states/entity/CustomerState.lua
+++ b/src/states/entity/CustomerState.lua
@@ -1,0 +1,10 @@
+CustomerState = class{__includes = BaseState}
+
+function CustomerState:init()
+end
+
+function CustomerState:update(dt)
+end
+
+function CustomerState:render()
+end

--- a/src/states/game/DayEndState.lua
+++ b/src/states/game/DayEndState.lua
@@ -5,9 +5,11 @@ end
 
 function DayEndState:update(dt)
     if love.keyboard.wasPressed('enter') or love.keyboard.wasPressed('return') then
-        -- End the DayEndState and return to the StartMenu
+        -- End the DayEndState and return to the PlayState (morning)
         gStateStack:pop()
-        gStateStack:push(StartMenu())
+        local playState = PlayState()
+        playState:enterParams({timeOfDay = 8})
+        gStateStack:push(playState)
     end
 end
 

--- a/src/states/game/PlayState.lua
+++ b/src/states/game/PlayState.lua
@@ -1,14 +1,20 @@
 PlayState = class {__includes = BaseState}
 
-function PlayState:init(timeOfDay)
-    -- If timeOfDay is provided, use it (in hours), else use default morning time (8:00 AM)
-    local startHour = timeOfDay or 8
-    self.dayTime = startHour * 60
+function PlayState:init()
+    -- Default to start hour 8 (8:00 AM)
+    self.dayTime = 8 * 60
     
     -- 1 real second = 15 game minutes
     self.timeScale = 15
     
     self.customerState = CustomerState()
+end
+
+function PlayState:enterParams(params)
+    -- If timeOfDay is provided in params, update dayTime
+    if params and params.timeOfDay then
+        self.dayTime = params.timeOfDay * 60
+    end
 end
 
 function PlayState:update(dt)

--- a/src/states/game/PlayState.lua
+++ b/src/states/game/PlayState.lua
@@ -1,12 +1,32 @@
 PlayState = class {__includes = BaseState}
 
-function PlayState:init()
-
+function PlayState:init(timeOfDay)
+    -- If timeOfDay is provided, use it (in hours), else use default morning time (8:00 AM)
+    local startHour = timeOfDay or 8
+    self.dayTime = startHour * 60
+    
+    -- 1 real second = 15 game minutes
+    self.timeScale = 15
+    
+    self.customerState = CustomerState()
 end
 
 function PlayState:update(dt)
+    self.customerState:update(dt)
+    
     if love.keyboard.wasPressed('enter') or love.keyboard.wasPressed('return') then
         -- End PlayState and enters DayEndState
+        gStateStack:pop()
+        gStateStack:push(DayEndState())
+        return
+    end
+    
+    -- Update timer
+    self.dayTime = self.dayTime + self.timeScale * dt
+    local currentHour = math.floor(self.dayTime / 60)
+    
+    -- Night time transition (8:00 PM / 20 hours)
+    if currentHour >= 20 then
         gStateStack:pop()
         gStateStack:push(DayEndState())
     end
@@ -16,4 +36,25 @@ function PlayState:render()
     love.graphics.rectangle('line', 0, 0, VIRTUAL_WIDTH, 20)
     love.graphics.rectangle('line', 0, 0.40 * VIRTUAL_HEIGHT + 20, VIRTUAL_WIDTH, 0.75 * VIRTUAL_HEIGHT)
     love.graphics.rectangle('line', 10, 25, 30, 0.40 * VIRTUAL_HEIGHT - 5)
+    
+    -- Timer UI
+    local hours = math.floor(self.dayTime / 60)
+    local minutes = math.floor(self.dayTime % 60)
+    
+    local period = "A.M."
+    local displayHour = hours % 24
+    if displayHour >= 12 then
+        period = "P.M."
+    end
+    
+    displayHour = displayHour % 12
+    if displayHour == 0 then
+        displayHour = 12
+    end
+    
+    local timeString = string.format("%02d:%02d %s", displayHour, minutes, period)
+    love.graphics.setFont(PixelFont)
+    love.graphics.print(timeString, VIRTUAL_WIDTH - 90, 2)
+    
+    self.customerState:render()
 end

--- a/src/states/game/StartMenu.lua
+++ b/src/states/game/StartMenu.lua
@@ -7,7 +7,9 @@ function StartMenu:update(dt)
     if love.keyboard.wasPressed('enter') or love.keyboard.wasPressed('return') then
         -- End StartMenu and enters PlayState
         gStateStack:pop()
-        gStateStack:push(PlayState())
+        local playState = PlayState()
+        playState:enterParams({timeOfDay = 8})
+        gStateStack:push(playState)
     end
 end
 


### PR DESCRIPTION
- Added CustomerState class in src/states/entity and properly included it in Dependencies.lua to establish the foundation for customer logic.
- Implemented an in-game timer inside PlayState that cycles from morning (8:00 A.M.) and converts real-life time to game time using a timeScale.
- Added UI text to visually render the formatted clock on the screen during the PlayState.
- Implemented state transition logic: PlayState automatically transitions to DayEndState when the clock hits 8:00 P.M. (or forced with Enter). DayEndState transitions back to the StartMenu state upon hitting Enter.
NOte -- We can change the timer later